### PR TITLE
Use HTML file instead of JSP to load swagger-ui

### DIFF
--- a/swagger-ui/build.gradle
+++ b/swagger-ui/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = 1.6
 ext {
   downloadUrl = "https://github.com/wordnik/swagger-ui/archive/v${swaggerUiVersion}.zip"
   destinationZip = "$buildDir/zip/${swaggerUiVersion}.zip"
-  replacePath = 'window.location.origin + "\\${pageContext.request.contextPath}/api-docs"'
+  replacePath = 'window.location.href.substring(0, window.location.href.lastIndexOf("/")) + "/api-docs"'
   artifactRepoBase = 'http://oss.jfrog.org/artifactory'
   artifactLabel = 'swagger-spring-mvc-ui'
 }
@@ -55,7 +55,7 @@ task sdoc(type: Copy) {
             .replaceAll('\\*/', '')
   }
 
-  rename('index.html', 'sdoc.jsp')
+  rename('index.html', 'sdoc.html')
 }
 
 task removeHtmlIndex(type: Delete) {


### PR DESCRIPTION
Due to Spring Boot's [limitations](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-developing-web-applications.html#boot-features-jsp-limitations) on JSP files, swagger-ui may not load
correctly when using in Spring Boot. I had issues like JSP files rendered as plain text or JSP expression not evaluated. 

In `sdoc.jsp` we only use JSP to get the context path, which can also be retrieved using JavaScript. Using HTML file is a more compatible approach for different frameworks. After this change, user can access `sdoc.html` for the Swagger UI.
